### PR TITLE
feat: add endpoint for get appointment details

### DIFF
--- a/src/appointments/appointments.controller.ts
+++ b/src/appointments/appointments.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   HttpCode,
   InternalServerErrorException,
+  NotFoundException,
   Param,
   Post,
   Put,
@@ -105,5 +106,21 @@ export class AppointmentsController {
   @HttpCode(204)
   public async remove(@Param('id') id: string): Promise<void> {
     return this.appointmentsService.remove(id);
+  }
+
+  @ApiOperation({ summary: 'Get details of appointment' })
+  @Get(':id')
+  @ApiResponse({
+    status: 404,
+    description: 'Appointment does not exist',
+    type: NotFoundException,
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Internal server expection error trying get details patient',
+    type: InternalServerErrorException,
+  })
+  public async getById(@Param('id') id: string): Promise<any> {
+    return this.appointmentsService.getById(id);
   }
 }

--- a/src/appointments/appointments.mocks.ts
+++ b/src/appointments/appointments.mocks.ts
@@ -3,11 +3,10 @@ import { Appointment } from './entities/appointment.entity';
 
 export class AppoitmentMocks {
   public appointment = {
-    id: '970bcb8c-b9eb-42bf-9069-efc76fe79dd9',
-    document: '33615840860',
-    startDateTime: '2023-02-25T14:40:00.000Z',
-    endDateTime: '2023-02-23T17:19:58.359Z',
-    patient: '7a8753cd-c898-437e-8d1b-10b7e386916d',
+    id: '1',
+    startDate: '2023-02-25T14:40:00.000Z',
+    endDate: '2023-02-23T17:19:58.359Z',
+    patientId: '1',
     createdAt: '2023-02-23T17:19:58.359Z',
     updatedAt: '2023-02-23T17:19:58.359Z',
   };

--- a/src/appointments/appointments.module.ts
+++ b/src/appointments/appointments.module.ts
@@ -4,9 +4,10 @@ import { Appointment } from './entities/appointment.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Patient } from '../patients/entities/patient.entity';
 import { AppointmentsService } from './appointments.service';
+import { Note } from 'src/notes/entities/note.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Appointment, Patient])],
+  imports: [TypeOrmModule.forFeature([Appointment, Patient, Note])],
   controllers: [AppointmentsController],
   providers: [AppointmentsService],
 })


### PR DESCRIPTION
O que foi feito?

Foi criado o endpoint de pegar os detalhes do agendamento para detalhar alguns dados como anotações e paciente que marcou aquela determinada consulta.

 Criado Endpoint de Detalhes da Consulta
 Atualização na service Service de Consulta
 Criado Testes